### PR TITLE
Add InstanceExists* methods to cloud provider interface for CCM

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -124,9 +124,10 @@ type Instances interface {
 	// ProviderID is a unique identifier of the node. This will not be called
 	// from the node whose nodeaddresses are being queried. i.e. local metadata
 	// services cannot be used in this method to obtain nodeaddresses
-	NodeAddressesByProviderID(providerId string) ([]v1.NodeAddress, error)
+	NodeAddressesByProviderID(providerID string) ([]v1.NodeAddress, error)
 	// ExternalID returns the cloud provider ID of the node with the specified NodeName.
 	// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
+	// Deprecated for the Cloud Controller Manager. Please use InstanceExists & InstanceExistsByProviderID instead.
 	ExternalID(nodeName types.NodeName) (string, error)
 	// InstanceID returns the cloud provider ID of the node with the specified NodeName.
 	InstanceID(nodeName types.NodeName) (string, error)
@@ -140,6 +141,16 @@ type Instances interface {
 	// CurrentNodeName returns the name of the node we are currently running on
 	// On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
 	CurrentNodeName(hostname string) (types.NodeName, error)
+	// InstanceExists returns true if the instance for the given node name still is running.
+	// If false is returned with no error, the instance will be immediately deleted.
+	// Note: The `cloudprovider.InstanceNotFound` error should not be returned here to notify
+	// the CCM that the instance is no longer running.
+	InstanceExists(nodeName types.NodeName) (bool, error)
+	// InstanceExistsByProviderID returns true if the instance for the given provider id still is running.
+	// If false is returned with no error, the instance will be immediately deleted.
+	// Note: The `cloudprovider.InstanceNotFound` error should not be returned here to notify
+	// the CCM that the instance is no longer running.
+	InstanceExistsByProviderID(providerID string) (bool, error)
 }
 
 // Route is a representation of an advanced routing rule.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1101,6 +1101,16 @@ func (c *Cloud) ExternalID(nodeName types.NodeName) (string, error) {
 	return orEmpty(instance.InstanceId), nil
 }
 
+// InstanceExists returns true if the instance with the given node name still exists and is running.
+func (c *Cloud) InstanceExists(nodeName types.NodeName) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+func (c *Cloud) InstanceExistsByProviderID(providerID string) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
 // InstanceID returns the cloud provider ID of the node with the specified nodeName.
 func (c *Cloud) InstanceID(nodeName types.NodeName) (string, error) {
 	// In the future it is possible to also return an endpoint as:

--- a/pkg/cloudprovider/providers/azure/azure_instances.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/api/core/v1"
@@ -84,6 +85,16 @@ func (az *Cloud) NodeAddressesByProviderID(providerID string) ([]v1.NodeAddress,
 // ExternalID returns the cloud provider ID of the specified instance (deprecated).
 func (az *Cloud) ExternalID(name types.NodeName) (string, error) {
 	return az.InstanceID(name)
+}
+
+// InstanceExists returns true if the instance with the given node name still exists and is running.
+func (az *Cloud) InstanceExists(nodeName types.NodeName) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+func (az *Cloud) InstanceExistsByProviderID(providerID string) (bool, error) {
+	return false, errors.New("unimplemented")
 }
 
 func (az *Cloud) isCurrentInstance(name types.NodeName) (bool, error) {

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -234,6 +234,18 @@ func (f *FakeCloud) InstanceTypeByProviderID(providerID string) (string, error) 
 	return f.InstanceTypes[types.NodeName(providerID)], nil
 }
 
+// InstanceExists returns true if the instance with the given node name still exists and is running.
+func (f *FakeCloud) InstanceExists(nodeName types.NodeName) (bool, error) {
+	f.addCall("instance-exists")
+	return f.Exists, f.Err
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+func (f *FakeCloud) InstanceExistsByProviderID(providerID string) (bool, error) {
+	f.addCall("instance-exists-by-provider-id")
+	return f.Exists, f.Err
+}
+
 // List is a test-spy implementation of Instances.List.
 // It adds an entry "list" into the internal method call record.
 func (f *FakeCloud) List(filter string) ([]types.NodeName, error) {

--- a/pkg/cloudprovider/providers/gce/gce_instances.go
+++ b/pkg/cloudprovider/providers/gce/gce_instances.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -152,6 +153,16 @@ func (gce *GCECloud) ExternalID(nodeName types.NodeName) (string, error) {
 		return "", err
 	}
 	return strconv.FormatUint(inst.ID, 10), nil
+}
+
+// InstanceExists returns true if the instance with the given node name still exists and is running.
+func (gce *GCECloud) InstanceExists(nodeName types.NodeName) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+func (gce *GCECloud) InstanceExistsByProviderID(providerID string) (bool, error) {
+	return false, errors.New("unimplemented")
 }
 
 // InstanceID returns the cloud provider ID of the node with the specified NodeName.

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -141,6 +141,16 @@ func (i *Instances) ExternalID(name types.NodeName) (string, error) {
 	return srv.ID, nil
 }
 
+// InstanceExists returns true if the instance with the given node name still exists and is running.
+func (i *Instances) InstanceExists(nodeName types.NodeName) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+func (i *Instances) InstanceExistsByProviderID(providerID string) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
 // InstanceID returns the kubelet's cloud provider ID.
 func (os *OpenStack) InstanceID() (string, error) {
 	if len(os.localInstanceID) == 0 {

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -211,6 +211,16 @@ func (v *OVirtCloud) ExternalID(nodeName types.NodeName) (string, error) {
 	return instance.UUID, nil
 }
 
+// InstanceExists returns true if the instance with the given node name still exists and is running.
+func (v *OVirtCloud) InstanceExists(nodeName types.NodeName) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+func (v *OVirtCloud) InstanceExistsByProviderID(providerID string) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
 // InstanceID returns the cloud provider ID of the node with the specified NodeName.
 func (v *OVirtCloud) InstanceID(nodeName types.NodeName) (string, error) {
 	name := mapNodeNameToInstanceName(nodeName)

--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -470,6 +470,16 @@ func (pc *PCCloud) ExternalID(nodeName k8stypes.NodeName) (string, error) {
 	}
 }
 
+// InstanceExists returns true if the instance with the given node name still exists and is running.
+func (pc *PCCLoud) InstanceExists(nodeName types.NodeName) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+func (pc *PCCLoud) InstanceExistsByProviderID(providerID string) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
 // InstanceID returns the cloud provider ID of the specified instance.
 func (pc *PCCloud) InstanceID(nodeName k8stypes.NodeName) (string, error) {
 	name := string(nodeName)

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -436,6 +436,16 @@ func (i *Instances) ExternalID(nodeName types.NodeName) (string, error) {
 	return probeInstanceID(i.compute, serverName)
 }
 
+// InstanceExists returns true if the instance with the given node name still exists and is running.
+func (i *Instances) InstanceExists(nodeName types.NodeName) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+func (i *Instances) InstanceExistsByProviderID(providerID string) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
 // InstanceID returns the cloud provider ID of the kubelet's instance.
 func (rs *Rackspace) InstanceID() (string, error) {
 	return readInstanceID()

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -376,6 +376,16 @@ func (vs *VSphere) ExternalID(nodeName k8stypes.NodeName) (string, error) {
 	return vs.InstanceID(nodeName)
 }
 
+// InstanceExists returns true if the instance with the given node name still exists and is running.
+func (vs *VSphere) InstanceExists(nodeName types.NodeName) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
+// InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
+func (vs *VSphere) InstanceExistsByProviderID(providerID string) (bool, error) {
+	return false, errors.New("unimplemented")
+}
+
 // InstanceID returns the cloud provider ID of the node with the specified Name.
 func (vs *VSphere) InstanceID(nodeName k8stypes.NodeName) (string, error) {
 	if vs.localInstanceID == nodeNameToVMName(nodeName) {

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -237,26 +237,36 @@ func (cnc *CloudNodeController) MonitorNode() {
 			if currentReadyCondition.Status != v1.ConditionTrue {
 				// Check with the cloud provider to see if the node still exists. If it
 				// doesn't, delete the node immediately.
-				if _, err := instances.ExternalID(types.NodeName(node.Name)); err != nil {
-					if err == cloudprovider.InstanceNotFound {
-						glog.V(2).Infof("Deleting node no longer present in cloud provider: %s", node.Name)
-						ref := &v1.ObjectReference{
-							Kind:      "Node",
-							Name:      node.Name,
-							UID:       types.UID(node.UID),
-							Namespace: "",
-						}
-						glog.V(2).Infof("Recording %s event message for node %s", "DeletingNode", node.Name)
-						cnc.recorder.Eventf(ref, v1.EventTypeNormal, fmt.Sprintf("Deleting Node %v because it's not present according to cloud provider", node.Name), "Node %s event: %s", node.Name, "DeletingNode")
-						go func(nodeName string) {
-							defer utilruntime.HandleCrash()
-							if err := cnc.kubeClient.CoreV1().Nodes().Delete(node.Name, nil); err != nil {
-								glog.Errorf("unable to delete node %q: %v", node.Name, err)
-							}
-						}(node.Name)
-					}
-					glog.Errorf("Error getting node data from cloud: %v", err)
+				exists, err := ensureNodeExistsByProviderIDOrName(instances, node)
+				if err != nil {
+					glog.Errorf("Error getting data for node %s from cloud: %v", node.Name, err)
+					continue
 				}
+
+				if exists {
+					// Continue checking the remaining nodes since the current one is fine.
+					continue
+				}
+
+				glog.V(2).Infof("Deleting node since it is no longer present in cloud provider: %s", node.Name)
+
+				ref := &v1.ObjectReference{
+					Kind:      "Node",
+					Name:      node.Name,
+					UID:       types.UID(node.UID),
+					Namespace: "",
+				}
+				glog.V(2).Infof("Recording %s event message for node %s", "DeletingNode", node.Name)
+
+				cnc.recorder.Eventf(ref, v1.EventTypeNormal, fmt.Sprintf("Deleting Node %v because it's not present according to cloud provider", node.Name), "Node %s event: %s", node.Name, "DeletingNode")
+
+				go func(nodeName string) {
+					defer utilruntime.HandleCrash()
+					if err := cnc.kubeClient.CoreV1().Nodes().Delete(nodeName, nil); err != nil {
+						glog.Errorf("unable to delete node %q: %v", nodeName, err)
+					}
+				}(node.Name)
+
 			}
 		}
 	}
@@ -370,6 +380,18 @@ func excludeTaintFromList(taints []v1.Taint, toExclude v1.Taint) []v1.Taint {
 		newTaints = append(newTaints, taint)
 	}
 	return newTaints
+}
+
+func ensureNodeExistsByProviderIDOrName(instances cloudprovider.Instances, node *v1.Node) (bool, error) {
+	exists, err := instances.InstanceExistsByProviderID(node.Spec.ProviderID)
+	if err != nil {
+		providerIDErr := err
+		exists, err = instances.InstanceExists(types.NodeName(node.Name))
+		if err != nil {
+			return false, fmt.Errorf("InstanceExists: Error fetching by providerID: %v Error fetching by NodeName: %v", providerIDErr, err)
+		}
+	}
+	return exists, nil
 }
 
 func getNodeAddressesByProviderIDOrName(instances cloudprovider.Instances, node *v1.Node) ([]v1.NodeAddress, error) {

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -105,9 +105,12 @@ func TestNodeDeleted(t *testing.T) {
 
 	eventBroadcaster := record.NewBroadcaster()
 	cloudNodeController := &CloudNodeController{
-		kubeClient:                fnh,
-		nodeInformer:              factory.Core().V1().Nodes(),
-		cloud:                     &fakecloud.FakeCloud{Err: cloudprovider.InstanceNotFound},
+		kubeClient:   fnh,
+		nodeInformer: factory.Core().V1().Nodes(),
+		cloud: &fakecloud.FakeCloud{
+			Exists: false,
+			Err:    nil,
+		},
 		nodeMonitorPeriod:         1 * time.Second,
 		recorder:                  eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cloud-controller-manager"}),
 		nodeStatusUpdateFrequency: 1 * time.Second,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Currently, [`MonitorNode()`](https://github.com/kubernetes/kubernetes/blob/02b520f0a40be2056d91fc0661c2b4fdb2694c30/pkg/controller/cloud/nodecontroller.go#L240) in the node controller checks with the CCM if a node still exists by calling `ExternalID(nodeName)`. `ExternalID` is supposed to return the provider id of a node which is not supported on every cloud. This means that any clouds who cannot infer the provider id by the node name from a remote location will never remove nodes that no longer exist. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50985

**Special notes for your reviewer**:

We'll want to create a subsequent issue to track the implementation of these two new methods in the cloud providers.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds `InstanceExists` and `InstanceExistsByProviderID` to cloud provider interface for the cloud controller manager
```

`cc @wlan0 @thockin @andrewsykim @luxas`

/area cloudprovider
/sig cluster-lifecycle